### PR TITLE
some modification when set a threshold to calculate connectivity

### DIFF
--- a/bin/cpa-sess
+++ b/bin/cpa-sess
@@ -95,7 +95,7 @@ def main():
                         required=True)
     parser.add_argument('-labelf',
                         help='Node label file',
-                        dest='labelf'
+                        dest='labelf',
                         required=True)
     parser.add_argument('-level',
                         help='voxel/roi level',

--- a/bin/cpa-sess
+++ b/bin/cpa-sess
@@ -95,7 +95,8 @@ def main():
                         required=True)
     parser.add_argument('-labelf',
                         help='Node label file',
-                        dest='labelf')
+                        dest='labelf'
+                        required=True)
     parser.add_argument('-level',
                         help='voxel/roi level',
                         dest='level',

--- a/cpa.py
+++ b/cpa.py
@@ -51,8 +51,8 @@ def pearson_correlation(D, w=None):
         R = c / np.sqrt(np.outer(d, d))
     
     # fisher-z transformation
-    R = np.arctanh
-
+    R = np.arctanh(R)
+    
     return R
 
 


### PR DESCRIPTION

@ Yuan-fang
The original code set the thr=None, which is okey. But if I wish to set an absolue value ,like 0.2, current code will give wrong results. Because all the value below the threshold will be set to 0 and when calculating mean connectivity, these zeros are counted as denominator.

I think we can add one line of code as following to avoid this problem:
sub_mat[sub_mat == 0] = np.nan

![code](https://user-images.githubusercontent.com/14069930/28236064-9ab89e04-694e-11e7-9c28-33a213a68989.png)

Hope I understand this correctly..... 
